### PR TITLE
Handle min_pool_cost in batch runs

### DIFF
--- a/batch-run.py
+++ b/batch-run.py
@@ -42,6 +42,9 @@ if __name__ == "__main__":
     parser.add_argument('--extra_pool_cost_fraction', nargs="*", type=float, default=0.4,
                         help='The factor that determines how much an additional pool costs as a fraction of '
                              'the original cost value of the stakeholder. Default is 40%%.')
+    parser.add_argument('--min_pool_cost', nargs="*", type=float, default=0.0,
+                        help='The minimum fixed fee that a pool must charge regardless of chosen cost. '
+                             'Default is 0.')
     parser.add_argument('--stake_distr_source', nargs="?", type=str, default='Pareto',
                         help='The distribution type to use for the initial allocation of stake to the agents.')
     parser.add_argument('--reward_scheme', nargs="?", type=int, default=0, choices=range(4),

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,12 +45,15 @@ myopic ones and that the myopic ones will be (roughly) twice as many as the abst
 **--cost_min**: The lowest initial cost that a stakeholder can have (acts as the lower bound of the Uniform distribution 
 that cost values are drawn from). The default value is 10<sup>-5</sup>, but any non-negative real number is accepted. 
 ---
-**--cost_max**: The highest initial cost that a stakeholder can have (acts as the upper bound of the Uniform 
-distribution that cost values are drawn from). The default value is 10<sup>-4</sup>, but any non-negative real number > 
-**cost_min** is accepted. 
+**--cost_max**: The highest initial cost that a stakeholder can have (acts as the upper bound of the Uniform
+distribution that cost values are drawn from). The default value is 10<sup>-4</sup>, but any non-negative real number >
+**cost_min** is accepted.
 ---
-**extra_pool_cost_fraction**: When an agent operates one pool, then the cost of the pool is equal to the cost of the 
-agent. However, in our simulation it's possible for agents to operate multiple pools, so we assume that each additional 
+**--min_pool_cost**: The protocol-enforced minimum fixed fee that a stake pool must charge. Any pool cost lower than
+this value is automatically raised to match it. The default value is 0.
+---
+**extra_pool_cost_fraction**: When an agent operates one pool, then the cost of the pool is equal to the cost of the
+agent. However, in our simulation it's possible for agents to operate multiple pools, so we assume that each additional
 pool an agent operates costs a fraction of their initial cost, and that fraction is the same for all agents and dictated 
 by this argument. The default value is 0.4 (i.e. that a second pool costs 0.4 times as much as the first), but any 
 non-negative real number is accepted (if we assume economies of scale then this value must be < 1, but if we assume some 

--- a/logic/helper.py
+++ b/logic/helper.py
@@ -560,6 +560,9 @@ def add_script_arguments(parser):
     parser.add_argument('--extra_pool_cost_fraction', nargs="?", type=non_negative_float, default=0.4,
                         help='The factor that determines how much an additional pool costs as a fraction of '
                              'the original cost value of the stakeholder. Default is 40%%.')
+    parser.add_argument('--min_pool_cost', nargs="?", type=non_negative_float, default=0.0,
+                        help='The minimum fixed fee that a pool must charge, regardless of the chosen cost. '
+                             'Default is 0.')
     parser.add_argument('--agent_activation_order', nargs="?", type=str.lower, default='random',
                         choices=['random', 'sequential', 'simultaneous', 'semisimultaneous'],
                         help='The order with which agents are activated. Default is "Random". Other options are '

--- a/logic/sim.py
+++ b/logic/sim.py
@@ -22,7 +22,7 @@ class Simulation(Model):
             self, n=1000, k=100, a0=0.3, stake_distr_source='Pareto', agent_profile_distr=None,
             inactive_stake_fraction=0, inactive_stake_fraction_known=False, relative_utility_threshold=0,
             absolute_utility_threshold=0, seed=None, pareto_param=2.0, max_iterations=1000, cost_min=1e-5,
-            cost_max=1e-4, extra_pool_cost_fraction=0.4, agent_activation_order="random",
+            cost_max=1e-4, extra_pool_cost_fraction=0.4, min_pool_cost=0.0, agent_activation_order="random",
             iterations_after_convergence=10, reward_scheme=0, execution_id='', seq_id=-1, parent_dir='',
             metrics=None, generate_graphs=True, input_from_file=False
     ):
@@ -71,7 +71,7 @@ class Simulation(Model):
 
         other_fields = [
             'n', 'k', 'a0', 'relative_utility_threshold', 'absolute_utility_threshold', 'max_iterations',
-            'extra_pool_cost_fraction', 'agent_activation_order', 'generate_graphs'
+            'extra_pool_cost_fraction', 'min_pool_cost', 'agent_activation_order', 'generate_graphs'
         ]
         multi_phase_params = {}
         for field in other_fields:
@@ -161,6 +161,7 @@ class Simulation(Model):
 
         # Allocate cost to the agents, sampling from a uniform distribution
         cost_distribution = hlp.generate_cost_distr_unfrm(num_agents=self.n, low=cost_min, high=cost_max, seed=seed)
+        cost_distribution = [max(c, self.min_pool_cost) for c in cost_distribution]
 
         agent_profiles = self.random.choices(list(profiles.PROFILE_MAPPING.keys()), k=self.n,
                                              weights=agent_profile_distr)

--- a/tests/test_min_pool_cost.py
+++ b/tests/test_min_pool_cost.py
@@ -1,0 +1,8 @@
+import logic.sim
+
+
+def test_min_pool_cost_enforced():
+    min_cost = 0.01
+    model = logic.sim.Simulation(n=10, min_pool_cost=min_cost)
+    for agent in model.get_agents_list():
+        assert agent.cost >= min_cost


### PR DESCRIPTION
## Summary
- add `--min_pool_cost` argument to batch-run
- ensure agent costs respect the minimum value when running batches

## Testing
- `pytest tests/test_min_pool_cost.py -q`
- `pytest -q` *(fails: test_helper, test_model_reporters, test_sim, test_stakeholder)*

------
https://chatgpt.com/codex/tasks/task_e_6852e8b56d34832dae36e83d8a85143b