### PR TITLE
Add min_pool_cost parameter

### DIFF
--- a/logic/sim.py
+++ b/logic/sim.py
@@ -22,7 +22,7 @@ class Simulation(Model):
             self, n=1000, k=100, a0=0.3, stake_distr_source='Pareto', agent_profile_distr=None,
             inactive_stake_fraction=0, inactive_stake_fraction_known=False, relative_utility_threshold=0,
             absolute_utility_threshold=0, seed=None, pareto_param=2.0, max_iterations=1000, cost_min=1e-5,
-            cost_max=1e-4, extra_pool_cost_fraction=0.4, agent_activation_order="random",
+            cost_max=1e-4, extra_pool_cost_fraction=0.4, min_pool_cost=0, agent_activation_order="random",
             iterations_after_convergence=10, reward_scheme=0, execution_id='', seq_id=-1, parent_dir='',
             metrics=None, generate_graphs=True, input_from_file=False
     ):
@@ -71,7 +71,7 @@ class Simulation(Model):
 
         other_fields = [
             'n', 'k', 'a0', 'relative_utility_threshold', 'absolute_utility_threshold', 'max_iterations',
-            'extra_pool_cost_fraction', 'agent_activation_order', 'generate_graphs'
+            'extra_pool_cost_fraction', 'min_pool_cost', 'agent_activation_order', 'generate_graphs'
         ]
         multi_phase_params = {}
         for field in other_fields:

--- a/logic/stakeholder.py
+++ b/logic/stakeholder.py
@@ -88,14 +88,23 @@ class Stakeholder(Agent):
         # Calculate current (not expected) utility of operating own pools
         for pool in self.strategy.owned_pools.values():
             utility += hlp.calculate_operator_utility_from_pool(
-                pool_stake=pool.stake, pledge=pool.pledge, margin=pool.margin, cost=pool.cost,
-                reward_scheme=self.model.reward_scheme
+                pool_stake=pool.stake,
+                pledge=pool.pledge,
+                margin=pool.margin,
+                cost=pool.cost,
+                reward_scheme=self.model.reward_scheme,
+                min_pool_cost=self.model.min_pool_cost,
             )
         for pool_id, allocation in self.strategy.stake_allocations.items():
             pool = self.model.pools[pool_id]
             utility += hlp.calculate_delegator_utility_from_pool(
-                stake_allocation=allocation, pool_stake=pool.stake, pledge=pool.pledge, margin=pool.margin,
-                cost=pool.cost, reward_scheme=self.model.reward_scheme
+                stake_allocation=allocation,
+                pool_stake=pool.stake,
+                pledge=pool.pledge,
+                margin=pool.margin,
+                cost=pool.cost,
+                reward_scheme=self.model.reward_scheme,
+                min_pool_cost=self.model.min_pool_cost,
             )
         return utility
 

--- a/logic/stakeholder_profiles.py
+++ b/logic/stakeholder_profiles.py
@@ -31,8 +31,12 @@ class NonMyopicStakeholder(Stakeholder):
         )
 
         return hlp.calculate_operator_utility_from_pool(
-            pool_stake=non_myopic_pool_stake, pledge=pool.pledge, margin=pool.margin, cost=pool.cost,
-            reward_scheme=self.model.reward_scheme
+            pool_stake=non_myopic_pool_stake,
+            pledge=pool.pledge,
+            margin=pool.margin,
+            cost=pool.cost,
+            reward_scheme=self.model.reward_scheme,
+            min_pool_cost=self.model.min_pool_cost,
         )
 
     def calculate_delegator_utility_from_pool(self, pool, stake_allocation):
@@ -49,7 +53,13 @@ class NonMyopicStakeholder(Stakeholder):
             current_stake
         )
         return hlp.calculate_delegator_utility_from_pool(
-            stake_allocation, pool_stake, pool.pledge, pool.margin, pool.cost, self.model.reward_scheme
+            stake_allocation,
+            pool_stake,
+            pool.pledge,
+            pool.margin,
+            pool.cost,
+            self.model.reward_scheme,
+            min_pool_cost=self.model.min_pool_cost,
         )
 
     def calculate_margins_and_utility(self, num_pools):
@@ -106,8 +116,12 @@ class MyopicStakeholder(Stakeholder):
         utility = 0
         for pool in potential_pools:
             pool_utility = hlp.calculate_operator_utility_from_pool(
-                pool_stake=pool.stake, pledge=pool.pledge, margin=pool.margin, cost=pool.cost,
-                reward_scheme=self.model.reward_scheme
+                pool_stake=pool.stake,
+                pledge=pool.pledge,
+                margin=pool.margin,
+                cost=pool.cost,
+                reward_scheme=self.model.reward_scheme,
+                min_pool_cost=self.model.min_pool_cost,
             )
             utility += pool_utility
         return utility
@@ -117,7 +131,13 @@ class MyopicStakeholder(Stakeholder):
             if pool.id in self.strategy.stake_allocations else 0
         current_stake = pool.stake - previous_allocation_to_pool + stake_allocation
         return hlp.calculate_delegator_utility_from_pool(
-            stake_allocation, current_stake, pool.pledge, pool.margin, pool.cost, self.model.reward_scheme
+            stake_allocation,
+            current_stake,
+            pool.pledge,
+            pool.margin,
+            pool.cost,
+            self.model.reward_scheme,
+            min_pool_cost=self.model.min_pool_cost,
         )
 
     def calculate_margins_and_utility(self, num_pools):
@@ -159,8 +179,12 @@ class MyopicStakeholder(Stakeholder):
                 )
             )
             utility += hlp.calculate_operator_utility_from_pool(
-                pool_stake=pool_saturation_threshold, pledge=pledge_per_pool, margin=margins[-1],
-                cost=cost_per_pool, reward_scheme=self.model.reward_scheme
+                pool_stake=pool_saturation_threshold,
+                pledge=pledge_per_pool,
+                margin=margins[-1],
+                cost=cost_per_pool,
+                reward_scheme=self.model.reward_scheme,
+                min_pool_cost=self.model.min_pool_cost,
             )
         return margins, utility
 


### PR DESCRIPTION
## Summary
- introduce `min_pool_cost` command-line argument
- propagate new parameter into `Simulation`
- include `min_pool_cost` in reward calculations for operators and delegators
- use `min_pool_cost` when agents compute utilities

## Testing
- `pytest -q` *(fails: fixture 'mocker' not found, several assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_6853194d7f84832d95a376ccd09df809